### PR TITLE
Quickfix: tailwind-eslint build failure

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,5 @@
+{
+  "semi": true,
+  "singleQuote": true,
+  "jsxSingleQuote": true
+}

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,5 +1,0 @@
-{
-  "semi": true,
-  "singleQuote": true,
-  "jsxSingleQuote": true
-}

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,5 @@
+{
+    "semi": true,
+    "singleQuote": true,
+    "jsxSingleQuote": true
+}

--- a/backend/.prettierignore
+++ b/backend/.prettierignore
@@ -1,0 +1,1 @@
+node_modules

--- a/backend/package.json
+++ b/backend/package.json
@@ -8,7 +8,7 @@
     "dev": "nodemon",
     "start": "node index.js",
     "test": "echo \"Error: no test specified\"",
-    "prettier": "npx prettier --write --ignore-path .prettierignore **/*.{js}"
+    "prettier": "npx prettier --write --ignore-path .prettierignore '**/**/*.js'"
   },
   "author": "",
   "license": "ISC",

--- a/backend/package.json
+++ b/backend/package.json
@@ -8,7 +8,7 @@
     "dev": "nodemon",
     "start": "node index.js",
     "test": "echo \"Error: no test specified\"",
-    "prettier": "npx prettier --write --ignore-path .prettierignore **/**/*.{js}"
+    "prettier": "npx prettier --write --ignore-path .prettierignore **/*.{js}"
   },
   "author": "",
   "license": "ISC",

--- a/backend/package.json
+++ b/backend/package.json
@@ -7,7 +7,8 @@
   "scripts": {
     "dev": "nodemon",
     "start": "node index.js",
-    "test": "echo \"Error: no test specified\""
+    "test": "echo \"Error: no test specified\"",
+    "prettier": "npx prettier --write --ignore-path .prettierignore **/**/*.{js}"
   },
   "author": "",
   "license": "ISC",

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -11,7 +11,6 @@
         "@testing-library/jest-dom": "^5.17.0",
         "@testing-library/react": "^13.4.0",
         "@testing-library/user-event": "^13.5.0",
-        "eslint-plugin-tailwindcss": "^3.15.1",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-router-dom": "^6.22.3",
@@ -19,6 +18,7 @@
         "web-vitals": "^2.1.4"
       },
       "devDependencies": {
+        "eslint-plugin-tailwindcss": "^3.15.1",
         "tailwindcss": "^3.4.1"
       }
     },
@@ -7894,6 +7894,7 @@
       "version": "3.15.1",
       "resolved": "https://registry.npmjs.org/eslint-plugin-tailwindcss/-/eslint-plugin-tailwindcss-3.15.1.tgz",
       "integrity": "sha512-4RXRMIaMG07C2TBEW1k0VM4+dDazz1kxcZhkK4zirvmHGZTA4jnlSO2kq5mamuSPi+Wo17dh2SlC8IyFBuCd7Q==",
+      "dev": true,
       "dependencies": {
         "fast-glob": "^3.2.5",
         "postcss": "^8.4.4"

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -6,7 +6,6 @@
     "@testing-library/jest-dom": "^5.17.0",
     "@testing-library/react": "^13.4.0",
     "@testing-library/user-event": "^13.5.0",
-    "eslint-plugin-tailwindcss": "^3.15.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-router-dom": "^6.22.3",
@@ -39,6 +38,7 @@
     ]
   },
   "devDependencies": {
+    "eslint-plugin-tailwindcss": "^3.15.1",
     "tailwindcss": "^3.4.1"
   }
 }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -14,6 +14,7 @@
   },
   "scripts": {
     "start": "react-scripts start",
+    "prettier": "npx prettier --write **/**/*.{js,jsx}",
     "build": "react-scripts build",
     "test": "react-scripts test",
     "eject": "react-scripts eject"

--- a/frontend/src/App.test.js
+++ b/frontend/src/App.test.js
@@ -2,11 +2,11 @@
 //checkout test case references below:
 //https://docs.google.com/spreadsheets/d/1ZgzcCNs2psKi8dMQaAKqk_NgzjTyLb68jNUiuGTq5P4/edit#gid=0
 
-import { render, screen } from "@testing-library/react";
-import App from "./App";
+import { render, screen } from '@testing-library/react';
+import App from './App';
 
-test("renders learn react link", () => {
+test('renders learn react link', () => {
   render(<App />);
-  const AppElement = screen.getByTestId("app");
+  const AppElement = screen.getByTestId('app');
   expect(AppElement).toBeInTheDocument();
 });

--- a/frontend/src/index.js
+++ b/frontend/src/index.js
@@ -8,7 +8,7 @@ const root = ReactDOM.createRoot(document.getElementById('root'));
 root.render(
   <React.StrictMode>
     <App />
-  </React.StrictMode>
+  </React.StrictMode>,
 );
 
 // If you want to start measuring performance in your app, pass a function

--- a/frontend/src/pages/cart.js
+++ b/frontend/src/pages/cart.js
@@ -1,7 +1,7 @@
 export default function Cart() {
   return (
-    <div data-testid="cart">
-      <div className="bg-blue-800 text-yellow-400 text-xl p-5 ">
+    <div data-testid='cart'>
+      <div className='bg-blue-800 p-5 text-xl text-yellow-400 '>
         This is your cart!
       </div>
     </div>

--- a/frontend/src/pages/home.js
+++ b/frontend/src/pages/home.js
@@ -1,23 +1,23 @@
 //navigate with buttons
-import { useNavigate } from "react-router";
+import { useNavigate } from 'react-router';
 
 export default function Home() {
   const navigate = useNavigate();
   return (
-    <div data-testid="home">
-      <div className=" bg-gradient-to-r from-blue-800 via-blue-500 to-blue-800 p-5 text-center text-4xl">
+    <div data-testid='home'>
+      <div className=' bg-gradient-to-r from-blue-800 via-blue-500 to-blue-800 p-5 text-center text-4xl'>
         Home page
       </div>
-      <div className="grid-rows-2 gap-x-4">
+      <div className='grid-rows-2 gap-x-4'>
         <button
-          onClick={() => navigate("/products")}
-          className="bg-purple-600 text-black font-bold p-4"
+          onClick={() => navigate('/products')}
+          className='bg-purple-600 p-4 font-bold text-black'
         >
           Our Products
         </button>
         <button
-          onClick={() => navigate("/cart")}
-          className="bg-purple-600 text-black font-bold p-4"
+          onClick={() => navigate('/cart')}
+          className='bg-purple-600 p-4 font-bold text-black'
         >
           Go to Cart
         </button>

--- a/frontend/src/pages/products.js
+++ b/frontend/src/pages/products.js
@@ -1,3 +1,3 @@
 export default function Product() {
-  return <div data-testid="products">Checkout our products :D</div>;
+  return <div data-testid='products'>Checkout our products :D</div>;
 }

--- a/frontend/src/pages/unit tests/cart.test.js
+++ b/frontend/src/pages/unit tests/cart.test.js
@@ -2,11 +2,11 @@
 //checkout test case references below:
 //https://docs.google.com/spreadsheets/d/1ZgzcCNs2psKi8dMQaAKqk_NgzjTyLb68jNUiuGTq5P4/edit#gid=0
 
-import { getByTestId, render, screen } from "@testing-library/react";
-import Cart from "../cart";
+import { getByTestId, render, screen } from '@testing-library/react';
+import Cart from '../cart';
 
-test("Cart Page rendered", () => {
+test('Cart Page rendered', () => {
   render(<Cart />);
-  const CartElement = screen.getByTestId("cart");
+  const CartElement = screen.getByTestId('cart');
   expect(CartElement).toBeInTheDocument();
 });

--- a/frontend/src/pages/unit tests/home.test.js
+++ b/frontend/src/pages/unit tests/home.test.js
@@ -2,16 +2,16 @@
 //checkout test case references below:
 //https://docs.google.com/spreadsheets/d/1ZgzcCNs2psKi8dMQaAKqk_NgzjTyLb68jNUiuGTq5P4/edit#gid=0
 
-import { render, screen, getByTestId } from "@testing-library/react";
-import Home from "../home";
-import { BrowserRouter } from "react-router-dom";
+import { render, screen, getByTestId } from '@testing-library/react';
+import Home from '../home';
+import { BrowserRouter } from 'react-router-dom';
 
-test("Home page rendered", () => {
+test('Home page rendered', () => {
   render(
     <BrowserRouter>
       <Home />
-    </BrowserRouter>
+    </BrowserRouter>,
   );
-  const HomeElement = screen.getByTestId("home");
+  const HomeElement = screen.getByTestId('home');
   expect(HomeElement).toBeInTheDocument();
 });

--- a/frontend/src/pages/unit tests/products.test.js
+++ b/frontend/src/pages/unit tests/products.test.js
@@ -2,11 +2,11 @@
 //checkout test case references below:
 //https://docs.google.com/spreadsheets/d/1ZgzcCNs2psKi8dMQaAKqk_NgzjTyLb68jNUiuGTq5P4/edit#gid=0
 
-import { screen, render, getByTestId } from "@testing-library/react";
-import Product from "../products";
+import { screen, render, getByTestId } from '@testing-library/react';
+import Product from '../products';
 
-test("Products Page Rendered!!", () => {
+test('Products Page Rendered!!', () => {
   render(<Product />);
-  const ProductElement = screen.getByTestId("products");
+  const ProductElement = screen.getByTestId('products');
   expect(ProductElement).toBeInTheDocument();
 });

--- a/frontend/src/reportWebVitals.js
+++ b/frontend/src/reportWebVitals.js
@@ -1,14 +1,12 @@
 const reportWebVitals = (onPerfEntry) => {
   if (onPerfEntry && onPerfEntry instanceof Function) {
-    import('web-vitals').then(
-      ({ getCLS, getFID, getFCP, getLCP, getTTFB }) => {
-        getCLS(onPerfEntry);
-        getFID(onPerfEntry);
-        getFCP(onPerfEntry);
-        getLCP(onPerfEntry);
-        getTTFB(onPerfEntry);
-      }
-    );
+    import('web-vitals').then(({ getCLS, getFID, getFCP, getLCP, getTTFB }) => {
+      getCLS(onPerfEntry);
+      getFID(onPerfEntry);
+      getFCP(onPerfEntry);
+      getLCP(onPerfEntry);
+      getTTFB(onPerfEntry);
+    });
   }
 };
 

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -1,9 +1,8 @@
 /** @type {import('tailwindcss').Config} */
 module.exports = {
-  content: ["./src/**/*.{html,js}"],
+  content: ['./src/**/*.{html,js}'],
   theme: {
     extend: {},
   },
   plugins: [],
-}
-
+};


### PR DESCRIPTION
# Issue
Build on frontend was failing while running npm install because of unordered classnames:
<img width="701" alt="Screenshot 2024-03-21 at 7 39 41 PM" src="https://github.com/hinchley2018/learning-ecommerce/assets/24418510/1029ddef-9c48-4944-9cdd-df31e5031d62">

# What was done
- The build failure may been because tailwind-eslint plugin was installed as a regular project dependency. To prevent this build failure in the future, I removed the plugin and added it as a dev dependency.  
- Ran `npx prettier write` 